### PR TITLE
Add cache directory option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [unreleased]
 
+### Added
+
+- Ability to specify the path to the cache directory (`--cache`) [[#43][43]]
+
+### Changed
+
+- Default cache dir is now `${HOME}/.cache` [[#43][43]]
+- Default output directory for all subcommands is now the current directory
+
 ## [0.2.0]
 
 ### Added
@@ -34,3 +43,4 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 [0.1.1]: https://github.com/mbhall88/tbpore/compare/0.1.0...0.1.1
 [0.1.0]: https://github.com/mbhall88/tbpore/releases/tag/0.1.0
 [34]: https://github.com/mbhall88/tbpore/issues/34
+[43]: https://github.com/mbhall88/tbpore/issues/43

--- a/README.md
+++ b/README.md
@@ -184,29 +184,32 @@ Usage: tbpore process [OPTIONS] [INPUTS]...
   same sample/isolate.
 
 Options:
-  -o, --outdir DIRECTORY          Directory to place output files  [default:
-                                  tbpore_out]
+  -h, --help                      Show this message and exit.
   -r, --recursive                 Recursively search INPUTS for fastq files
-  --tmp DIRECTORY                 Specify where to write all (tbpore)
-                                  temporary files. [default: <outdir>/.tbpore]
   -S, --name TEXT                 Name of the sample. By default, will use the
                                   first INPUT file with any extensions
                                   stripped
-  -t, --threads INTEGER           Number of threads to use in multithreaded
-                                  tools  [default: 1]
   -A, --report_all_mykrobe_calls  Report all mykrobe calls (turn on flag -A,
                                   --report_all_calls when calling mykrobe)
+  --db PATH                       Path to the decontaminaton database
+                                  [default: /Users/michaelhall/Projects/tbpore
+                                  /data/decontamination_db/tbpore.remove_conta
+                                  m.fa.gz.map-ont.mmi]
+  -m, --metadata PATH             Path to the decontaminaton database metadata
+                                  file  [default: /Users/michaelhall/Projects/
+                                  tbpore/data/decontamination_db/remove_contam
+                                  .tsv.gz]
+  -o, --outdir DIRECTORY          Directory to place output files  [default:
+                                  .]
+  --tmp DIRECTORY                 Specify where to write all (tbpore)
+                                  temporary files. [default: <outdir>/.tbpore]
+  -t, --threads INTEGER           Number of threads to use in multithreaded
+                                  tools  [default: 1]
   -d, --cleanup / -D, --no-cleanup
                                   Remove all temporary files on *successful*
                                   completion  [default: no-cleanup]
-  --db PATH                       Path to the decontaminaton database
-                                  [default: <project_root_dir>/data
-                                  /decontamination_db
-                                  /tbpore.remove_contam.fa.gz.map-ont.mmi]
-  -m, --metadata PATH             Path to the decontaminaton database metadata
-                                  file [default: <project_root_dir>/data
-                                  /decontamination_db/remove_contam.tsv.gz]
-  --help                          Show this message and exit.
+  --cache DIRECTORY               Path to use for the cache  [default:
+                                  /Users/michaelhall/.cache]
 ```
 
 ## cluster subcommand
@@ -223,9 +226,10 @@ Usage: tbpore cluster [OPTIONS] [INPUTS]...
   several easily (e.g. output/sample_*/*.consensus.fa).
 
 Options:
+  -h, --help                      Show this message and exit.
   -T, --threshold INTEGER         Clustering threshold  [default: 6]
   -o, --outdir DIRECTORY          Directory to place output files  [default:
-                                  cluster_out]
+                                  .]
   --tmp DIRECTORY                 Specify where to write all (tbpore)
                                   temporary files. [default: <outdir>/.tbpore]
   -t, --threads INTEGER           Number of threads to use in multithreaded
@@ -233,7 +237,8 @@ Options:
   -d, --cleanup / -D, --no-cleanup
                                   Remove all temporary files on *successful*
                                   completion  [default: no-cleanup]
-  --help                          Show this message and exit.
+  --cache DIRECTORY               Path to use for the cache  [default:
+                                  /Users/michaelhall/.cache]
 ```
 
 [channels]: https://bioconda.github.io/#usage

--- a/tbpore/constants.py
+++ b/tbpore/constants.py
@@ -4,10 +4,10 @@ TMP_NAME = ".tbpore"
 repo_root = Path(__file__).parent.parent.resolve()
 H37RV_genome = repo_root / "data/H37RV_genome/h37rv.fa.gz"
 H37RV_mask = repo_root / "data/H37RV_genome/compass-mask.bed"
-decontamination_db_index = (
+DECONTAMINATION_DB_INDEX = (
     repo_root / "data/decontamination_db/tbpore.remove_contam.fa.gz.map-ont.mmi"
 )
-decontamination_db_metadata = repo_root / "data/decontamination_db/remove_contam.tsv.gz"
-cache_dir = repo_root / ".cache"
-config_file = repo_root / ".config.yaml"
-external_scripts_dir = repo_root / "external_scripts"
+DECONTAMINATION_DB_METADATA = repo_root / "data/decontamination_db/remove_contam.tsv.gz"
+CACHE_DIR = Path.home() / ".cache"
+CONFIG_FILE = repo_root / ".config.yaml"
+EXTERNAL_SCRIPTS_DIR = repo_root / "external_scripts"

--- a/tbpore/tbpore.py
+++ b/tbpore/tbpore.py
@@ -120,6 +120,14 @@ def common_opts(func):
     """
 
     @click.option(
+        "-o",
+        "--outdir",
+        help="Directory to place output files",
+        default=".",
+        show_default=True,
+        type=click.Path(file_okay=False, writable=True, path_type=Path),
+    )
+    @click.option(
         "--tmp",
         help=(
             f"Specify where to write all (tbpore) temporary files. [default: "
@@ -184,14 +192,7 @@ def main_cli(
 
 
 @main_cli.command()
-@click.option(
-    "-o",
-    "--outdir",
-    help="Directory to place output files",
-    default="tbpore_out",
-    show_default=True,
-    type=click.Path(file_okay=False, writable=True, path_type=Path),
-)
+@click.help_option("-h", "--help")
 @click.option(
     "-r", "--recursive", help="Recursively search INPUTS for fastq files", is_flag=True
 )
@@ -228,7 +229,6 @@ def main_cli(
 )
 @common_opts
 @click.argument("inputs", type=click.Path(exists=True, path_type=Path), nargs=-1)
-@click.help_option("-h", "--help")
 @click.pass_context
 def process(
     ctx: click.Context,
@@ -442,14 +442,6 @@ def process(
     type=int,
     show_default=True,
     default=6,
-)
-@click.option(
-    "-o",
-    "--outdir",
-    help="Directory to place output files",
-    default="cluster_out",
-    show_default=True,
-    type=click.Path(file_okay=False, writable=True, path_type=Path),
 )
 @common_opts
 @click.argument("inputs", type=click.Path(exists=True, path_type=Path), nargs=-1)

--- a/tests/test_tbpore_cluster.py
+++ b/tests/test_tbpore_cluster.py
@@ -54,6 +54,7 @@ class TestClusterCLI:
                 fp.write("@r1\nACGT\n+$$$%\n")
             opts = ["cluster", "-o", str(td), str(infile_1), str(infile_2)]
             result = runner.invoke(main_cli, opts)
+            print(result)
             assert result.exit_code == 0
 
             assert run_core_mock.call_count == 1

--- a/tests/test_tbpore_process.py
+++ b/tests/test_tbpore_process.py
@@ -9,13 +9,13 @@ from click.testing import CliRunner
 
 from tbpore.external_tools import ExternalTool
 from tbpore.tbpore import (
+    CACHE_DIR,
+    DECONTAMINATION_DB_INDEX,
+    DECONTAMINATION_DB_METADATA,
+    EXTERNAL_SCRIPTS_DIR,
     TMP_NAME,
     H37RV_genome,
     H37RV_mask,
-    cache_dir,
-    decontamination_db_index,
-    decontamination_db_metadata,
-    external_scripts_dir,
     main_cli,
 )
 
@@ -50,7 +50,7 @@ class TestExternalToolsExecution:
             )
             assert (
                 map_decontamination_db_cl
-                == f"minimap2 -aL2 -x map-ont -t 1 -o {td}/{TMP_NAME}/in.decontaminated.sam {decontamination_db_index} {td}/{TMP_NAME}/in.fq.gz"
+                == f"minimap2 -aL2 -x map-ont -t 1 -o {td}/{TMP_NAME}/in.decontaminated.sam {DECONTAMINATION_DB_INDEX} {td}/{TMP_NAME}/in.fq.gz"
             )
 
             sort_decontaminated_sam_cl = self.get_command_line_from_mock(
@@ -72,7 +72,7 @@ class TestExternalToolsExecution:
             filter_contamination_cl = self.get_command_line_from_mock(run_core_mock, 3)
             assert (
                 filter_contamination_cl
-                == f"{sys.executable} {external_scripts_dir}/filter_contamination.py --verbose --ignore-secondary -o {td}/{TMP_NAME}/in.decontaminated.filter -i {td}/{TMP_NAME}/in.decontaminated.sorted.bam -m {decontamination_db_metadata}"
+                == f"{sys.executable} {EXTERNAL_SCRIPTS_DIR}/filter_contamination.py --verbose --ignore-secondary -o {td}/{TMP_NAME}/in.decontaminated.filter -i {td}/{TMP_NAME}/in.decontaminated.sorted.bam -m {DECONTAMINATION_DB_METADATA}"
             )
 
             extract_decontaminated_nanopore_reads_cl = self.get_command_line_from_mock(
@@ -92,7 +92,7 @@ class TestExternalToolsExecution:
             mykrobe_cl = self.get_command_line_from_mock(run_core_mock, 6)
             assert (
                 mykrobe_cl
-                == f"mykrobe predict --sample in -t 1 --tmp {td}/{TMP_NAME} --skeleton_dir {cache_dir} --ont "
+                == f"mykrobe predict --sample in -t 1 --tmp {td}/{TMP_NAME} --skeleton_dir {CACHE_DIR} --ont "
                 f"--format json --min_proportion_expected_depth 0.20 --species tb "
                 f"-m 2048MB -o {td}/in.mykrobe.json -i {td}/{TMP_NAME}/in.subsampled.fastq.gz"
             )
@@ -128,7 +128,7 @@ class TestExternalToolsExecution:
             filter_vcf_cl = self.get_command_line_from_mock(run_core_mock, 11)
             assert (
                 filter_vcf_cl
-                == f"{sys.executable} {external_scripts_dir}/apply_filters.py -P --verbose --overwrite -d 0 -D 0 "
+                == f"{sys.executable} {EXTERNAL_SCRIPTS_DIR}/apply_filters.py -P --verbose --overwrite -d 0 -D 0 "
                 f"-q 85 -s 1 -b 0 -m 0 -r 0 -V 1e-05 -G 0 -K 0.9 -M 0 -x 0.2 "
                 f"-o {td}/in.snps.filtered.bcf -i {td}/{TMP_NAME}/in.subsampled.snps.vcf"
             )
@@ -136,7 +136,7 @@ class TestExternalToolsExecution:
             generate_consensus_cl = self.get_command_line_from_mock(run_core_mock, 12)
             assert (
                 generate_consensus_cl
-                == f"{sys.executable} {external_scripts_dir}/consensus.py --sample-id in --verbose --ignore all "
+                == f"{sys.executable} {EXTERNAL_SCRIPTS_DIR}/consensus.py --sample-id in --verbose --ignore all "
                 f"--het-default none -o {td}/in.consensus.fa -i {td}/in.snps.filtered.bcf "
                 f"-f {H37RV_genome} -m {H37RV_mask}"
             )
@@ -177,7 +177,7 @@ class TestExternalToolsExecution:
             )
             assert (
                 map_decontamination_db_cl
-                == f"minimap2 -aL2 -x map-ont -t 8 -o {td}/custom_tmp/custom_name.decontaminated.sam {decontamination_db_index} {td}/custom_tmp/custom_name.fq.gz"
+                == f"minimap2 -aL2 -x map-ont -t 8 -o {td}/custom_tmp/custom_name.decontaminated.sam {DECONTAMINATION_DB_INDEX} {td}/custom_tmp/custom_name.fq.gz"
             )
 
             sort_decontaminated_sam_cl = self.get_command_line_from_mock(
@@ -199,7 +199,7 @@ class TestExternalToolsExecution:
             filter_contamination_cl = self.get_command_line_from_mock(run_core_mock, 3)
             assert (
                 filter_contamination_cl
-                == f"{sys.executable} {external_scripts_dir}/filter_contamination.py --verbose --ignore-secondary -o {td}/custom_tmp/custom_name.decontaminated.filter -i {td}/custom_tmp/custom_name.decontaminated.sorted.bam -m {decontamination_db_metadata}"
+                == f"{sys.executable} {EXTERNAL_SCRIPTS_DIR}/filter_contamination.py --verbose --ignore-secondary -o {td}/custom_tmp/custom_name.decontaminated.filter -i {td}/custom_tmp/custom_name.decontaminated.sorted.bam -m {DECONTAMINATION_DB_METADATA}"
             )
 
             extract_decontaminated_nanopore_reads_cl = self.get_command_line_from_mock(
@@ -220,7 +220,7 @@ class TestExternalToolsExecution:
             mykrobe_cl = self.get_command_line_from_mock(run_core_mock, 6)
             assert (
                 mykrobe_cl
-                == f"mykrobe predict -A --sample custom_name -t 8 --tmp {td}/custom_tmp --skeleton_dir {cache_dir} --ont "
+                == f"mykrobe predict -A --sample custom_name -t 8 --tmp {td}/custom_tmp --skeleton_dir {CACHE_DIR} --ont "
                 f"--format json --min_proportion_expected_depth 0.20 --species tb "
                 f"-m 2048MB -o {td}/custom_name.mykrobe.json -i {td}/custom_tmp/custom_name.subsampled.fastq.gz"
             )
@@ -256,7 +256,7 @@ class TestExternalToolsExecution:
             filter_vcf_cl = self.get_command_line_from_mock(run_core_mock, 11)
             assert (
                 filter_vcf_cl
-                == f"{sys.executable} {external_scripts_dir}/apply_filters.py -P --verbose --overwrite -d 0 -D 0 "
+                == f"{sys.executable} {EXTERNAL_SCRIPTS_DIR}/apply_filters.py -P --verbose --overwrite -d 0 -D 0 "
                 f"-q 85 -s 1 -b 0 -m 0 -r 0 -V 1e-05 -G 0 -K 0.9 -M 0 -x 0.2 "
                 f"-o {td}/custom_name.snps.filtered.bcf -i {td}/custom_tmp/custom_name.subsampled.snps.vcf"
             )
@@ -264,7 +264,7 @@ class TestExternalToolsExecution:
             generate_consensus_cl = self.get_command_line_from_mock(run_core_mock, 12)
             assert (
                 generate_consensus_cl
-                == f"{sys.executable} {external_scripts_dir}/consensus.py --sample-id custom_name --verbose --ignore all "
+                == f"{sys.executable} {EXTERNAL_SCRIPTS_DIR}/consensus.py --sample-id custom_name --verbose --ignore all "
                 f"--het-default none -o {td}/custom_name.consensus.fa -i {td}/custom_name.snps.filtered.bcf "
                 f"-f {H37RV_genome} -m {H37RV_mask}"
             )
@@ -312,7 +312,7 @@ class TestExternalToolsExecution:
             )
             assert (
                 map_decontamination_db_cl
-                == f"minimap2 -aL2 -x map-ont -t 1 -o {td}/{TMP_NAME}/in.decontaminated.sam {decontamination_db_index} {td}/{TMP_NAME}/in.fq.gz"
+                == f"minimap2 -aL2 -x map-ont -t 1 -o {td}/{TMP_NAME}/in.decontaminated.sam {DECONTAMINATION_DB_INDEX} {td}/{TMP_NAME}/in.fq.gz"
             )
 
             sort_decontaminated_sam_cl = self.get_command_line_from_mock(


### PR DESCRIPTION
This PR closes #43 

### Added

- Ability to specify the path to the cache directory (`--cache`) [#43]

### Changed

- Default cache dir is now `${HOME}/.cache` [#43]
- Default output directory for all subcommands is now the current directory

I also cleaned up some of the path validation for various files.