### PR TITLE
Remove only fastq extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [unreleased]
 
+### Changed
+
+- When `--name` is not given, take name to be the filename minus the fastq (and optional gz) suffix. Previously, we took everything before the first `.` [[#45][45]]
+
 ## [0.3.1]
 
 ### Fixed
@@ -54,3 +58,4 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 [0.1.0]: https://github.com/mbhall88/tbpore/releases/tag/0.1.0
 [34]: https://github.com/mbhall88/tbpore/issues/34
 [43]: https://github.com/mbhall88/tbpore/issues/43
+[45]: https://github.com/mbhall88/tbpore/issues/45

--- a/README.md
+++ b/README.md
@@ -187,8 +187,8 @@ Options:
   -h, --help                      Show this message and exit.
   -r, --recursive                 Recursively search INPUTS for fastq files
   -S, --name TEXT                 Name of the sample. By default, will use the
-                                  first INPUT file with any extensions
-                                  stripped
+                                  first INPUT file with fastq extensions
+                                  removed
   -A, --report_all_mykrobe_calls  Report all mykrobe calls (turn on flag -A,
                                   --report_all_calls when calling mykrobe)
   --db PATH                       Path to the decontaminaton database

--- a/environment.yaml
+++ b/environment.yaml
@@ -5,7 +5,6 @@ channels:
   - defaults
 dependencies:
   - "python>=3.8,<4.0"
-  - mamba
   - just=0.10
   - ca-certificates
   - certifi

--- a/tbpore/tbpore.py
+++ b/tbpore/tbpore.py
@@ -25,6 +25,7 @@ from tbpore.clustering import produce_clusters
 from tbpore.external_tools import ExternalTool
 from tbpore.utils import (
     concatenate_fastqs,
+    fastq_prefix,
     find_fastq_files,
     parse_verbose_filter_params,
 )
@@ -273,7 +274,7 @@ def process(
         )
 
     if not name:
-        name = inputs[0].name.split(".")[0]
+        name = fastq_prefix(inputs[0])
         if not name:
             name = "input"
         logger.debug(f"No sample name found; using '{name}'")

--- a/tbpore/tbpore.py
+++ b/tbpore/tbpore.py
@@ -200,8 +200,8 @@ def main_cli(
     "-S",
     "--name",
     help=(
-        "Name of the sample. By default, will use the first INPUT file with any "
-        "extensions stripped"
+        "Name of the sample. By default, will use the first INPUT file with fastq "
+        "extensions removed"
     ),
 )
 @click.option(

--- a/tbpore/utils.py
+++ b/tbpore/utils.py
@@ -55,3 +55,8 @@ def parse_verbose_filter_params(filters_dict: Dict[Any, Any]) -> str:
         if key in filters_dict:
             flags.append(f"-{op} {filters_dict[key]}")
     return " ".join(flags)
+
+
+def fastq_prefix(path: Union[str, Path]) -> str:
+    fname = Path(path).name
+    return re.sub(r"\.f(ast)?q(\.gz)?$", "", fname, count=1)

--- a/tbpore/utils.py
+++ b/tbpore/utils.py
@@ -59,4 +59,4 @@ def parse_verbose_filter_params(filters_dict: Dict[Any, Any]) -> str:
 
 def fastq_prefix(path: Union[str, Path]) -> str:
     fname = Path(path).name
-    return re.sub(r"\.f(ast)?q(\.gz)?$", "", fname, count=1)
+    return FASTQ_REGEX.sub("", fname, count=1)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from unittest import mock
 
-from tbpore.utils import find_fastq_files, is_fastq
+from tbpore.utils import fastq_prefix, find_fastq_files, is_fastq
 
 
 class TestIsFastq:
@@ -78,3 +78,24 @@ def test_find_fastq_files(mock_iglob, mock_is_file):
     )
 
     assert actual == expected
+
+
+class TestFastqPrefix:
+    def test_no_fastq_prefix_returns_input_filename(self):
+        path = "path/to/my.file"
+
+        actual = fastq_prefix(path)
+        expected = Path(path).name
+
+        assert actual == expected
+
+    def test_all_fastq_extensions_return_the_same(self):
+        exts = ["fastq", "fq", "fastq.gz", "fq.gz"]
+
+        expected = "my.file"
+        for ext in exts:
+            path = f"path/to/my.file.{ext}"
+
+            actual = fastq_prefix(path)
+
+            assert actual == expected


### PR DESCRIPTION
Closes #45 

### Changed

- When `--name` is not given, take name to be the filename minus the fastq (and optional gz) suffix. Previously, we took everything before the first `.` [#45]
